### PR TITLE
All children tick at `frequency` rate with correct deltas.

### DIFF
--- a/src/hxbt/BehaviorTree.hx
+++ b/src/hxbt/BehaviorTree.hx
@@ -43,7 +43,7 @@ class BehaviorTree
 			m_counter = this.frequency;
 			if (m_tree != null)
 			{
-				m_tree.tick(m_context, dt);
+				m_tree.tick(m_context, this.frequency);
 			}
 		}
 	}

--- a/src/hxbt/Sequence.hx
+++ b/src/hxbt/Sequence.hx
@@ -23,6 +23,14 @@ class Sequence extends Composite
 		m_currentIndex = 0;
 	}
 	
+	override function onTerminate(context : Dynamic, status : Status)
+	{
+		for(_child in m_children)
+		{
+			_child.status = Status.INVALID;
+		}
+	}
+	
 	override function update(context : Dynamic, dt : Float) : Status
 	{
 		//	Keep looping until a child says it is running.


### PR DESCRIPTION
They used to fire up tick with delta from tree's update. Now my `Wait` Behavior correctly counts 1 second :)
