### PR TITLE
Changed Selector and Sequence logic.

### DIFF
--- a/src/hxbt/composites/Selector.hx
+++ b/src/hxbt/composites/Selector.hx
@@ -10,11 +10,13 @@ class Selector<T> extends Composite<T>
 {
 	private var m_currentChild : Behavior<T>;
 	private var m_currentIndex : Int;
+	private var m_allChildrenTick:Bool;
+
 	
-	
-	public function new() 
+	public function new(allChildrenTick:Bool = false) 
 	{
 		super();
+		m_allChildrenTick = allChildrenTick;
 	}
 	
 	override function onInitialize(context : T)
@@ -29,8 +31,30 @@ class Selector<T> extends Composite<T>
 			_child.status = Status.INVALID;
 		}
 	}
+
+	function updateAllChildren(context : T, dt : Float) : Status
+	{
+		var status:Status;
+		for(index in m_currentIndex...m_children.length)
+		{
+			m_currentIndex = index;
+			m_currentChild = m_children[index];
+			status = m_currentChild.tick(context, dt);
+			if(status == SUCCESS)
+			{
+				m_currentIndex = 0;
+				return SUCCESS;
+			}			
+			else if(status == RUNNING)
+			{
+				return RUNNING;
+			}
+		}
+		m_currentIndex = 0;
+		return FAILURE;
+	}
 	
-	override function update(context : T, dt : Float) : Status
+	function updateChildPerChild(context : T, dt : Float) : Status
 	{
 		m_currentChild = m_children[m_currentIndex];
 		var s = m_currentChild.tick(context, dt);
@@ -50,6 +74,18 @@ class Selector<T> extends Composite<T>
 		}
 
 		return Status.RUNNING;
+	}
+
+	override function update(context : T, dt : Float) : Status
+	{
+		if(m_allChildrenTick)
+		{
+			return updateAllChildren(context, dt);
+		}
+		else
+		{
+			return updateChildPerChild(context, dt);
+		}
 	}
 	
 }


### PR DESCRIPTION
Added a way to go through all children of a Selector or Sequence.

I was inspired by a lua library (which was used for my first attempts to use BT) that runs the sequencers/selectors fully instead of progressing one child per tick.

Such a change could be justified by some of my tests were containing sequences that uses this way of managing conditions + actions, where the last leaf of the Sequencer is the actual action.
![This way](http://outforafight.files.wordpress.com/2014/07/image08.png)

I kep the orginal code and allowed the developer to switch from your way to manage logic and the changes I added by a simple boolean. This is far from optimal and I wonder if something like this would justify creating instead different classes.

Have a nice day.